### PR TITLE
Add Research page with theme aligned components

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,6 +32,8 @@
     --nature-green: 120 40% 80%;
     --nature-brown: 30 20% 50%;
     --nature-sky: 200 70% 80%;
+    --computation-blue: 210 60% 70%;
+    --computation-gray: 220 20% 60%;
   }
 }
 

--- a/src/app/research.tsx
+++ b/src/app/research.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+const Research = () => {
+  return (
+    <div className="container mx-auto py-10">
+      <h1 className="text-3xl font-bold mb-6">QCX Research</h1>
+      <p className="mb-4">
+        Welcome to the QCX Research page. Here, we delve into the fascinating world of nature and computation research, focusing on quality computer experience.
+      </p>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">Nature Research</h2>
+        <p>
+          Our nature research focuses on understanding the intricate relationships within ecosystems and how they can be modeled and simulated using advanced computational techniques. This research aims to enhance our understanding of natural processes and contribute to the development of sustainable solutions for environmental challenges.
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">Computation Research</h2>
+        <p>
+          In the realm of computation research, we explore cutting-edge technologies and methodologies to improve the quality of computer experiences. This includes developing new algorithms, optimizing existing systems, and creating innovative applications that leverage the power of artificial intelligence and machine learning.
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">Multi-Agent Architectures</h2>
+        <p>
+          Our research also delves into the development of new multi-agent architectures. These architectures enable the creation of complex systems where multiple agents can interact, collaborate, and make decisions autonomously. This research has significant implications for various fields, including robotics, automation, and artificial intelligence.
+        </p>
+      </section>
+      <section className="mb-6">
+        <h2 className="text-2xl font-semibold mb-4">Intelligence Benchmarks</h2>
+        <p>
+          We are committed to establishing new intelligence benchmarks that push the boundaries of what is possible with artificial intelligence. These benchmarks serve as a standard for evaluating the performance and capabilities of AI systems, driving continuous improvement and innovation in the field.
+        </p>
+      </section>
+    </div>
+  );
+};
+
+export default Research;

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -24,6 +24,7 @@ export default function SiteHeader() {
                                 <Link href={"#features"} className={"text-white/70 hover:text-white transition"}>Features</Link>
                                 <Link href={"#pricing"} className={"text-white/70 hover:text-white transition"}>Pricing</Link>
                                 <Link href={"#careers"} className={"text-white/70 hover:text-white transition"}>Careers</Link>
+                                <Link href={"/research"} className={"text-white/70 hover:text-white transition"}>Research</Link>
                             </nav>
                         </section>
                         <section className={"flex max-md:gap-4 items-center"}>
@@ -52,6 +53,10 @@ export default function SiteHeader() {
                                             <Link href={"#careers"} className={"flex items-center gap-3 text-white/70 hover:text-white transition"}>
                                                 <Newspaper className={"size-6"} />
                                                 Careers
+                                            </Link>
+                                            <Link href={"/research"} className={"flex items-center gap-3 text-white/70 hover:text-white transition"}>
+                                                <CodeXml className={"size-6"} />
+                                                Research
                                             </Link>
                                         </nav>
                                     </div>


### PR DESCRIPTION
Add a Research tab to the main task bar and create a new research page with theme-aligned components for Nature and computation research.

* **Main Task Bar**
  - Add a new `Link` component for the Research tab in `src/components/site-header.tsx` that routes to `/research`.

* **Research Page**
  - Create a new `Research` component in `src/app/research.tsx` with the title "QCX Research".
  - Add a description for the research page.
  - Add details about nature and computation research on quality computer experience.
  - Add information about new multi-agent architectures and intelligence benchmarks.
  - Export the `Research` component as the default export.

* **CSS Variables**
  - Add CSS variables for Nature and computation research themes in `src/app/globals.css`.

