### PR TITLE
Update enterprise pricing tier in pricing section

### DIFF
--- a/src/components/pricing-section.tsx
+++ b/src/components/pricing-section.tsx
@@ -19,8 +19,8 @@ const pricingTiers = [
   },
   {
     title: 'Enterprise',
-    price: 'Contact Us',
-    features: ['SLAs', 'Customizations', 'Extensive Support', 'Security'],
+    price: '$$$$+/Month',
+    features: ['SLAs', 'Customizations', 'Extensive Support', 'Extensive Security'],
   },
 ];
 


### PR DESCRIPTION
Update the enterprise pricing section on the pricing page.

* Change the enterprise pricing tier price to "$$$$+/Month".
* Update the enterprise pricing tier features to include "Extensive Security" instead of "Security".

