### PR TITLE
Fix pricing capitalization for Standard and Exclusive plans

### DIFF
--- a/src/components/pricing-section.tsx
+++ b/src/components/pricing-section.tsx
@@ -9,12 +9,12 @@ const pricingTiers = [
   },
   {
     title: 'Standard',
-    price: '$21+/month',
+    price: '$21+/Month',
     features: ['Internet Search', 'Upload and analyze unlimited files', 'Mapping tools', 'Location Intelligence'],
   },
   {
     title: 'Exclusive',
-    price: '$52+/month',
+    price: '$52+/Month',
     features: ['Everything in Standard', 'Browser Agents', 'Physics Models', 'Environment Aware *', 'Exclusive Updates'],
   },
   {


### PR DESCRIPTION
Update the pricing for Standard and Exclusive plans to have a capital 'M' for Month.

* Change the pricing for "Standard" to "$21+/Month" in `src/components/pricing-section.tsx`
* Change the pricing for "Exclusive" to "$52+/Month" in `src/components/pricing-section.tsx`

