### PR TITLE
Add Research tab to task bar

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -24,7 +24,7 @@ export default function SiteHeader() {
                                 <Link href={"#features"} className={"text-white/70 hover:text-white transition"}>Features</Link>
                                 <Link href={"#pricing"} className={"text-white/70 hover:text-white transition"}>Pricing</Link>
                                 <Link href={"#careers"} className={"text-white/70 hover:text-white transition"}>Careers</Link>
-                                <Link href={"https://www.nature.com/"} className={"text-white/70 hover:text-white transition"}>Research</Link>
+                                <Link href={"/research"} className={"text-white/70 hover:text-white transition"}>Research</Link>
                             </nav>
                         </section>
                         <section className={"flex max-md:gap-4 items-center"}>
@@ -54,7 +54,7 @@ export default function SiteHeader() {
                                                 <Newspaper className={"size-6"} />
                                                 Careers
                                             </Link>
-                                            <Link href={"https://www.nature.com/"} className={"flex items-center gap-3 text-white/70 hover:text-white transition"}>
+                                            <Link href={"/research"} className={"flex items-center gap-3 text-white/70 hover:text-white transition"}>
                                                 <CodeXml className={"size-6"} />
                                                 Research
                                             </Link>


### PR DESCRIPTION
Add a new navigation link for "Research" in the task bar and mobile menu in `src/components/site-header.tsx` that routes to `/research`.

* **Task Bar Navigation Link**
  - Change the "Research" link to route to `/research` instead of an external URL.

* **Mobile Menu Navigation Link**
  - Change the "Research" link to route to `/research` instead of an external URL.

