### PR TITLE
Fix the research tab routing issue

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import {clsx} from "clsx";
 import { Roboto } from "next/font/google";
+import Research from "./research"; // P1311
 
 const inter = Inter({ subsets: ["latin"] });
 const roboto = Roboto({ subsets: ["latin"], weight: ["400", "700"] });
@@ -19,7 +20,8 @@ export default function RootLayout({children,}: Readonly<{ children: React.React
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={clsx(inter.className, roboto.className, "antialiased")}>
-      {children}
+        <Research /> {/* Pbae7 */}
+        {children}
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { Features } from "@/components/features";
 import { Testimonials } from "@/components/testimonials";
 import { GithubIndicator } from "@/components/github-indicator";
 import { PricingSection } from "@/components/pricing-section";
+import Research from "./research"; // P8e64
 
 export default function Home() {
     return (
@@ -18,6 +19,7 @@ export default function Home() {
             <Testimonials />
             <PricingSection id="pricing" />
             <CallToAction id="careers" />
+            <Research /> {/* P5d93 */}
             <GithubIndicator />
             <SiteFooter />
         </>


### PR DESCRIPTION
Add a route for the research page to the layout and home components.

* **Layout Component**
  - Import the `Research` component in `src/app/layout.tsx`.
  - Include the `Research` component in the `RootLayout` function.

* **Home Component**
  - Import the `Research` component in `src/app/page.tsx`.
  - Include the `Research` component in the `Home` function.

