### PR TITLE
Replace physical science with natural science

### DIFF
--- a/src/components/call-to-action.tsx
+++ b/src/components/call-to-action.tsx
@@ -65,7 +65,7 @@ export function CallToAction({ id }: { id: string }) {
     </h2>
     <p>
         A highly concurrent multi-agent orchestration framework for extensive context switching 
-        and context continuity, designed for physical science research and integration within our products.
+        and context continuity, designed for natural science research and integration within our products.
     </p>
 
     <h2 className="text-xl md:text-2xl text-white font-bold mt-5">


### PR DESCRIPTION
Replace the term "physical science" with "natural science" in the `src/components/call-to-action.tsx` file.

* Update the "Environment Aware Agents" section to reflect the change from "physical science" to "natural science" in the context of research and integration within products.

