### PR TITLE
Replace GitHub logo with X logo

### DIFF
--- a/src/components/github-indicator.tsx
+++ b/src/components/github-indicator.tsx
@@ -1,12 +1,12 @@
-import {GitHubLogoIcon} from "@radix-ui/react-icons";
+import X from "@/assets/social-x.svg";
 import Link from "next/link";
 
 export function GithubIndicator() {
     return (
         <>
-            <Link href={"https://github.com/queuelab"} target={"_blank"}
+            <Link href={"https://x.com/tryqcx"} target={"_blank"}
                 className={"fixed bottom-6 right-6 z-50 size-12 border flex items-center justify-center rounded-full bg-black/70 hover:bg-muted transition"}>
-                <GitHubLogoIcon className={"size-6"}/>
+                <X className={"size-6"}/>
             </Link>
         </>
     )

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,4 +1,3 @@
-import X from "@/assets/social-x.svg"
 import SiteLogo from "@/assets/logo.svg";
 import Link from "next/link";
 
@@ -30,16 +29,6 @@ export default function SiteFooter() {
                     </a>
                         .
                     </p>
-                    <div>
-                        <ul className={"flex justify-center gap-3 text-white/40"}>
-                            <li className={"hover:text-white cursor-pointer"}>
-                                <div className={"flex flex-col items-center"}>
-                                    <X/>
-                                    <Link href="https://x.com/tryqcx"></Link>
-                                </div>
-                            </li>
-                        </ul>
-                    </div>
                 </div>
             </footer>
         </>


### PR DESCRIPTION
Replace the GitHub logo on the bottom right of the page with the X logo and update the link.

* Replace the `GitHubLogoIcon` with the `X` logo in `src/components/github-indicator.tsx`.
* Update the `href` in `src/components/github-indicator.tsx` to "https://x.com/tryqcx".
* Remove the `X` logo from the footer in `src/components/site-footer.tsx`.

