### PR TITLE
Remove the OpenAI logo from the list of trusted partners

### DIFF
--- a/src/components/logo-ticker.tsx
+++ b/src/components/logo-ticker.tsx
@@ -3,7 +3,6 @@
 import MsLogo from "@/assets/logo-ms.png";
 import GithubLogo from "@/assets/logo-github.png";
 import AwsLogo from "@/assets/logo-aws (1).png";
-import OpenAILogo from "@/assets/logo-openai.png";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
@@ -42,7 +41,7 @@ export function LogoTicker() {
                           ease: "linear",
                       }}
                       className={"flex flex-none gap-14 pr-14 -translate-x-1/2"}>
-                      {[MsLogo, GithubLogo, AwsLogo, OpenAILogo, MsLogo, GithubLogo, AwsLogo, OpenAILogo].map((logo, index) => (
+                      {[MsLogo, GithubLogo, AwsLogo, MsLogo, GithubLogo, AwsLogo].map((logo, index) => (
                           <Image src={logo} alt={`${logo}`} key={index} className={"h-6 w-auto"}/>
                       ))}
                   </motion.div>


### PR DESCRIPTION
Remove the OpenAI logo from the list of trusted partners.

* Remove the import statement for the OpenAI logo.
* Remove the OpenAI logo from the array of logos in the ticker.

