### PR TITLE
Add chat interface and animations to HeroSection

### DIFF
--- a/src/components/hero-section.tsx
+++ b/src/components/hero-section.tsx
@@ -3,9 +3,11 @@
 import { ActionButton } from "./action-button";
 import BackgroundStars from "@/assets/stars.png";
 import {motion, useScroll, useTransform} from "framer-motion";
-import {useRef} from "react";
+import {useRef, useState} from "react";
 
 export function HeroSection() {
+    const [isAnimating, setIsAnimating] = useState(false);
+    const [showChatInput, setShowChatInput] = useState(false);
 
     const sectionRef = useRef<HTMLElement>(null);
     const { scrollYProgress } = useScroll({
@@ -13,6 +15,19 @@ export function HeroSection() {
         offset: [`start end`, 'end start']
     })
     const backgroundPositionY = useTransform(scrollYProgress, [0, 1], [-300, 300])
+
+    const handleGetStartedClick = () => {
+        setIsAnimating(true);
+        setTimeout(() => {
+            setShowChatInput(true);
+        }, 2000); // Adjust the duration to match the animation
+    };
+
+    const handleChatSubmit = (event) => {
+        event.preventDefault();
+        const question = event.target.elements.question.value;
+        window.open(`https://earth.queue.cx?question=${encodeURIComponent(question)}`, '_blank');
+    };
 
     return (
         <>
@@ -23,7 +38,11 @@ export function HeroSection() {
                 style={{backgroundImage: `url(${BackgroundStars.src})`, backgroundPositionY}} ref={sectionRef}>
                 <div className={"absolute inset-0 bg-[radial-gradient(75%_75%_at_center_center,rgb(0,0,255,0.5)_15%,rgb(14,0,36,0.5)_78%,transparent)]"} />
                 {/* Planet Logic */}
-                <div className={"absolute size-64 md:size-96 bg-blue-500 rounded-full border border-white/20 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-[radial-gradient(50%_50%_at_16.8%_18.3%,white,rgb(0,0,255)_37.7%,rgb(24,0,66))] shadow-[-20px_-20px_50px_rgb(255,255,255,0.5),-20px_-20px_80px_rgb(255,255,255,0.1),0_0_50px_rgb(0,0,255)]"} />
+                <motion.div
+                    className={"absolute size-64 md:size-96 bg-blue-500 rounded-full border border-white/20 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-[radial-gradient(50%_50%_at_16.8%_18.3%,white,rgb(0,0,255)_37.7%,rgb(24,0,66))] shadow-[-20px_-20px_50px_rgb(255,255,255,0.5),-20px_-20px_80px_rgb(255,255,255,0.1),0_0_50px_rgb(0,0,255)]"}
+                    animate={isAnimating ? { y: -100 } : {}}
+                    transition={{ duration: 2 }}
+                />
                 {/* Rings + Mini planets Logic */}
                 <motion.div
                     style={{translateY: '-50%', translateX: '-50%',}}
@@ -50,14 +69,40 @@ export function HeroSection() {
                     <div className={"absolute size-2 bg-white rounded-full top-1/2 left-full -translate-x-1/2 -translate-y-1/2"}/>
                 </motion.div>
                 {/* Hero Section Content Logic */}
-                <div className={"container relative mt-16"}>
+                <motion.div
+                    className={"container relative mt-16"}
+                    animate={isAnimating ? { opacity: 0 } : {}}
+                    transition={{ duration: 1 }}
+                >
                     <h1 className={"text-8xl md:text-[168px] md:leading-none font-semibold bg-white tracking-tighter bg-[radial-gradient(100%_100%_at_top_left,white,white,rgb(0,0,255,0.5))] bg-clip-text text-transparent text-center"}>QCX</h1>
                     <p className={"font-handwriting text-lg md:text-xl max-w-xl mx-auto text-white/70 mt-5 text-center italic flex justify-center"}>is a multi-agent intelligence platform for exploration and automation. Your planetary copilot, everything for your</p> 
                     <span className={"text-sm tracking-wider text-[#7CFC00] flex justify-center"}>QUALITY COMPUTER EXPERIENCE </span>
                     <div className={"flex justify-center mt-5"}>
-                        <ActionButton label={"Get Started"} href={"https://tally.so/r/wkWqkd"} />
+                        <button onClick={handleGetStartedClick} className={"relative py-2 px-3 rounded-lg font-medium text-sm bg-gradient-to-b from-[#1a1a1a] to-[#333333] shadow-[0px_0px_12px_#0000FF]"}>
+                            <div className={"absolute inset-0 rounded-lg"}>
+                                <div className={"absolute inset-0 border rounded-lg border-white/20 [mask-image:linear-gradient(to_bottom,black,transparent)]"} />
+                                <div className={"absolute inset-0 border rounded-lg border-white/40 [mask-image:linear-gradient(to_top,black,transparent)]"} />
+                                <div className={"absolute inset-0 rounded-lg shadow-[0_0_10px_rgb(0,0,255,0.7)_inset]"} />
+                            </div>
+                            <span className={"text-[#7CFC00]"}>Get Started</span>
+                        </button>
                     </div>
-                </div>
+                </motion.div>
+                {showChatInput && (
+                    <div className={"container relative mt-16"}>
+                        <form onSubmit={handleChatSubmit} className={"flex justify-center mt-5"}>
+                            <input type="text" name="question" placeholder="Ask a question..." className={"py-2 px-3 rounded-lg font-medium text-sm bg-gradient-to-b from-[#1a1a1a] to-[#333333] shadow-[0px_0px_12px_#0000FF] text-[#7CFC00]"} />
+                            <button type="submit" className={"ml-2 relative py-2 px-3 rounded-lg font-medium text-sm bg-gradient-to-b from-[#1a1a1a] to-[#333333] shadow-[0px_0px_12px_#0000FF]"}>
+                                <div className={"absolute inset-0 rounded-lg"}>
+                                    <div className={"absolute inset-0 border rounded-lg border-white/20 [mask-image:linear-gradient(to_bottom,black,transparent)]"} />
+                                    <div className={"absolute inset-0 border rounded-lg border-white/40 [mask-image:linear-gradient(to_top,black,transparent)]"} />
+                                    <div className={"absolute inset-0 rounded-lg shadow-[0_0_10px_rgb(0,0,255,0.7)_inset]"} />
+                                </div>
+                                <span className={"text-[#7CFC00]"}>Send</span>
+                            </button>
+                        </form>
+                    </div>
+                )}
             </motion.section>
         </>
     )


### PR DESCRIPTION
Implement animation and chat input functionality for the "Get Started" button in the Hero Section.

* Add state to manage animation and chat input visibility.
* Update the "Get Started" button to trigger the animation and show chat input.
* Add animation to fade out the texts and push up the sphere.
* Create a chat input interface underneath the sphere after the animation completes.
* Implement functionality to launch the question into another chat bot linked at `earth.queue.cx`.

