### PR TITLE
Fix Pro plan PayPal link

### DIFF
--- a/src/components/pricing-section.tsx
+++ b/src/components/pricing-section.tsx
@@ -50,7 +50,7 @@ export function PricingSection({ id }: { id: string }) {
                 {tier.title === 'Enterprise' ? (
                   <ActionButton label="Contact Us" href="mailto:support@queue.cx" />
                 ) : (
-                  <ActionButton label={`${tier.price} - ${tier.title}`} href={tier.title === 'Standard' ? "https://www.paypal.com/ncp/payment/V4DU34TVVWY76" : tier.title === 'Premium' ? "https://www.paypal.com/ncp/payment/B72MURM7SZ7MN" : "https://www.paypal.com/ncp/payment/5K2S6VPMMVUXA"} />
+                  <ActionButton label={`${tier.price} - ${tier.title}`} href={tier.title === 'Standard' ? "https://www.paypal.com/ncp/payment/V4DU34TVVWY76" : tier.title === 'Pro' ? "https://www.paypal.com/ncp/payment/B72MURM7SZ7MN" : "https://www.paypal.com/ncp/payment/5K2S6VPMMVUXA"} />
                 )}
               </div>
             </div>


### PR DESCRIPTION
Update the PayPal link for the Pro plan in the pricing section.

* Change the `href` attribute for the Pro plan's `ActionButton` to "https://www.paypal.com/ncp/payment/B72MURM7SZ7MN" in `src/components/pricing-section.tsx`.
* Rename the plan from 'Premium' to 'Pro' in the conditional statement for the `ActionButton`'s `href` attribute.

