### PR TITLE
Fix: Correct navigation links on reads page

### DIFF
--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -46,15 +46,15 @@ export default function SiteHeader() {
                                                 <Feather className="size-6" />
                                                 Home
                                             </Link>
-                                            <Link href="#features" className="flex items-center gap-3 text-white/70 hover:text-white transition">
+                                            <Link href="/#features" className="flex items-center gap-3 text-white/70 hover:text-white transition">
                                                 <Feather className="size-6" />
                                                 Products
                                             </Link>
-                                            <Link href="#pricing" className="flex items-center gap-3 text-white/70 hover:text-white transition">
+                                            <Link href="/#pricing" className="flex items-center gap-3 text-white/70 hover:text-white transition">
                                                 <Wallet2 className="size-6" />
                                                 Pricing
                                             </Link>
-                                            <Link href="#careers" className="flex items-center gap-3 text-white/70 hover:text-white transition">
+                                            <Link href="/#careers" className="flex items-center gap-3 text-white/70 hover:text-white transition">
                                                 <Newspaper className="size-6" />
                                                 Research
                                             </Link>


### PR DESCRIPTION
The navigation links for 'Products', 'Pricing', and 'Research' on the /reads page were not working correctly. They were using fragment identifiers (#section) which attempted to find sections on the /reads page itself, instead of navigating to the main page sections.

This commit updates the href attributes for these links in src/components/site-header.tsx to correctly point to the main page sections (e.g., /#features). This fix applies to both the desktop and mobile navigation menus.

I verified the links by building the application and inspecting the rendered HTML of the /reads page to ensure the href attributes were correctly formed.