### PR TITLE
Enhance Reads Page Design and Functionality

### DIFF
--- a/src/app/reads/page.tsx
+++ b/src/app/reads/page.tsx
@@ -1,16 +1,37 @@
-import React from "react";
+import React, { useRef } from "react";
 import SiteHeader from "@/components/site-header";
 import SiteFooter from "@/components/site-footer";
 import CallToAction  from "@/components/call-to-action";
+import BackgroundStars from "@/assets/stars.png";
+import { motion, useScroll, useTransform } from "framer-motion";
 
 export default function ReadsPage() {
+  const sectionRef = useRef<HTMLElement>(null);
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: [`start end`, 'end start']
+  });
+  const backgroundPositionY = useTransform(scrollYProgress, [0, 1], [-300, 300]);
+  const readsCount = 3; // Manually counted <details> elements
+
   return (
     <React.Fragment>
-      <SiteHeader />
-      <section className="py-20 md:py-24">
-        <div className="container">
+      <SiteHeader readsCount={readsCount} />
+      <motion.section
+        ref={sectionRef}
+        animate={{ backgroundPositionX: BackgroundStars.width }}
+        transition={{ duration: 120, repeat: Infinity, ease: 'linear' }}
+        style={{
+          backgroundImage: `url(${BackgroundStars.src})`,
+          backgroundPositionY,
+        }}
+        className="relative overflow-hidden [mask-image:linear-gradient(to_bottom,transparent,black_10%,black_90%,transparent)]"
+      >
+        <div className={"absolute inset-0 bg-[radial-gradient(75%_75%_at_center_center,rgb(0,0,255,0.5)_15%,rgb(14,0,36,0.5)_78%,transparent)]"} />
+        {/* The div below used to be the <section> tag. We move its padding classes here and make it relative. */}
+        <div className="container py-20 md:py-24 relative">
           <details className="mb-8">
-            <summary className="text-5xl tracking-tighter text-center font-medium cursor-pointer">
+            <summary className="text-5xl tracking-tighter text-center font-medium cursor-pointer border border-white/20 p-4 rounded-lg hover:bg-white/5">
               QueueCX
             </summary>
             <div className="text-center text-sm text-white/50 mt-2">
@@ -35,7 +56,7 @@ export default function ReadsPage() {
           </details>
 
           <details className="mb-8">
-            <summary className="text-5xl tracking-tighter text-center font-medium cursor-pointer">
+            <summary className="text-5xl tracking-tighter text-center font-medium cursor-pointer border border-white/20 p-4 rounded-lg hover:bg-white/5">
               Environment Aware
             </summary>
             <div className="text-center text-sm text-white/50 mt-2">
@@ -88,7 +109,7 @@ export default function ReadsPage() {
           </details>
 
           <details className="mb-8">
-            <summary className="text-5xl tracking-tighter text-center font-medium cursor-pointer">
+            <summary className="text-5xl tracking-tighter text-center font-medium cursor-pointer border border-white/20 p-4 rounded-lg hover:bg-white/5">
               Fluidity Index
             </summary>
             <div className="text-center text-sm text-white/50 mt-2">💦</div>
@@ -98,6 +119,7 @@ export default function ReadsPage() {
           </details>
         </div>
       </section>
+      </motion.section>
       <SiteFooter />
     </React.Fragment>
   );

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -11,7 +11,11 @@ import { useAuth } from '@/components/auth-provider'; // New import
 import { AuthForm } from '@/components/auth-form';   // New import
 import { ActionButton } from '@/components/action-button';
 
-export default function SiteHeader() {
+interface SiteHeaderProps {
+  readsCount?: number;
+}
+
+export default function SiteHeader({ readsCount }: SiteHeaderProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [isDemoModalOpen, setIsDemoModalOpen] = useState(false);
     const { user, loading: authLoading, signOut } = useAuth(); // Get auth state
@@ -36,7 +40,9 @@ export default function SiteHeader() {
                                 <Link href="/#features" className="text-white/70 hover:text-white transition">Products</Link>
                                 <Link href="/#pricing" className="text-white/70 hover:text-white transition">Pricing</Link>
                                 <Link href="/#careers" className="text-white/70 hover:text-white transition">Research</Link>
-                                <Link href="/reads" className="text-white/70 hover:text-white transition">Reads</Link>
+                                <Link href="/reads" className="text-white/70 hover:text-white transition">
+                                  Reads {readsCount && readsCount > 0 ? `(${readsCount})` : ''}
+                                </Link>
                             </nav>
                         </section>
                         <section className="flex max-md:gap-4 items-center">
@@ -89,7 +95,7 @@ export default function SiteHeader() {
                                             </Link>
                                             <Link href="/reads" className="flex items-center gap-3 text-white/70 hover:text-white transition">
                                                 <Newspaper className="size-6" />
-                                                Reads
+                                                Reads {readsCount && readsCount > 0 ? `(${readsCount})` : ''}
                                             </Link>
                                         </nav>
                                     </div>


### PR DESCRIPTION
This commit introduces several improvements to the /reads page:

1.  **Stars Background and Cursor Overlay:**
    - Added a dynamic stars background and a blue radial gradient overlay, similar to the Hero section on the main page. This provides a consistent visual experience.
    - Utilizes the existing `stars.png` asset and `framer-motion` for animations.

2.  **Post Count Display:**
    - The number of posts (currently static based on `<details>` elements) on the Reads page is now counted.
    - This count is displayed next to the "Reads" link in both the desktop and mobile navigation menus in the `SiteHeader` component (e.g., "Reads (3)").

3.  **Improved Read Item Styling:**
    - The `<summary>` elements for each read item have been styled with a border, padding, rounded corners, and a hover effect to make them more visually distinct and interactive.

These changes address the issue of improving the design and functionality of the Reads page, making it more engaging and informative.