### PR TITLE
Fix: Display reads post counter consistently in SiteHeader

### DIFF
--- a/src/app/reads/page.tsx
+++ b/src/app/reads/page.tsx
@@ -14,11 +14,10 @@ export default function ReadsPage() {
     offset: [`start end`, 'end start']
   });
   const backgroundPositionY = useTransform(scrollYProgress, [0, 1], [-300, 300]);
-  const readsCount = 3; // Manually counted <details> elements
 
   return (
     <React.Fragment>
-      <SiteHeader readsCount={readsCount} />
+      <SiteHeader />
       <motion.section
         ref={sectionRef}
         animate={{ backgroundPositionX: BackgroundStars.width }}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -11,11 +11,12 @@ import { useAuth } from '@/components/auth-provider'; // New import
 import { AuthForm } from '@/components/auth-form';   // New import
 import { ActionButton } from '@/components/action-button';
 
+const STATIC_READS_COUNT = 3;
+
 interface SiteHeaderProps {
-  readsCount?: number;
 }
 
-export default function SiteHeader({ readsCount }: SiteHeaderProps) {
+export default function SiteHeader({}: SiteHeaderProps) {
     const [isOpen, setIsOpen] = useState(false);
     const [isDemoModalOpen, setIsDemoModalOpen] = useState(false);
     const { user, loading: authLoading, signOut } = useAuth(); // Get auth state
@@ -40,9 +41,11 @@ export default function SiteHeader({ readsCount }: SiteHeaderProps) {
                                 <Link href="/#features" className="text-white/70 hover:text-white transition">Products</Link>
                                 <Link href="/#pricing" className="text-white/70 hover:text-white transition">Pricing</Link>
                                 <Link href="/#careers" className="text-white/70 hover:text-white transition">Research</Link>
-                                <Link href="/reads" className="text-white/70 hover:text-white transition">
-                                  Reads {readsCount && readsCount > 0 ? `(${readsCount})` : ''}
-                                </Link>
+                                {STATIC_READS_COUNT && STATIC_READS_COUNT > 0 && (
+                                  <Link href="/reads" className="text-white/70 hover:text-white transition">
+                                    Reads ({STATIC_READS_COUNT})
+                                  </Link>
+                                )}
                             </nav>
                         </section>
                         <section className="flex max-md:gap-4 items-center">
@@ -93,10 +96,12 @@ export default function SiteHeader({ readsCount }: SiteHeaderProps) {
                                                 <Newspaper className="size-6" />
                                                 Research
                                             </Link>
-                                            <Link href="/reads" className="flex items-center gap-3 text-white/70 hover:text-white transition">
-                                                <Newspaper className="size-6" />
-                                                Reads {readsCount && readsCount > 0 ? `(${readsCount})` : ''}
-                                            </Link>
+                                            {STATIC_READS_COUNT && STATIC_READS_COUNT > 0 && (
+                                              <Link href="/reads" className="flex items-center gap-3 text-white/70 hover:text-white transition">
+                                                  <Newspaper className="size-6" />
+                                                  Reads ({STATIC_READS_COUNT})
+                                              </Link>
+                                            )}
                                         </nav>
                                     </div>
                                 </SheetContent>


### PR DESCRIPTION
The reads post counter in the SiteHeader will now be displayed consistently across all pages.

Previously, the counter was only shown when the `readsCount` prop was explicitly passed to the SiteHeader, which typically only happened on the `/reads` page. This meant the counter was missing on other pages like the homepage.

This change modifies the `SiteHeader` component to manage the `readsCount` internally using a static constant. This ensures the counter is always visible, reflecting the number of articles on the reads page, regardless of the current page.

The `reads/page.tsx` has also been updated to remove the now-redundant `readsCount` prop passing.