### PR TITLE
feat: Add loading bar to auth form

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,3 +46,14 @@
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes propel {
+  0% {
+    transform: translateX(-20%);
+    opacity: 0.7;
+  }
+  100% {
+    transform: translateX(0%);
+    opacity: 1;
+  }
+}

--- a/src/components/auth-form.tsx
+++ b/src/components/auth-form.tsx
@@ -156,6 +156,18 @@ export function AuthForm() {
                         </button>
                     </div>
                 </form>
+
+                {loading && (
+                    <div className="mt-6 h-2.5 w-full rounded-full bg-gray-700/60 overflow-hidden">
+                        <div
+                            className="h-2.5 rounded-full bg-sky-500"
+                            style={{
+                                width: `75%`,
+                                animation: 'propel 1s ease-in-out infinite alternate',
+                            }}
+                        ></div>
+                    </div>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
Implemented a loading bar at the bottom of the authentication pop-up.
- The loading bar appears when the form is submitting.
- It is styled to fit the existing design and has a propelling animation.
- The progress bar is initially set to 75% width.