### PR TITLE
feat: Add Vercel Analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-slot": "^1.1.0",
         "@supabase/supabase-js": "^2.50.0",
+        "@vercel/analytics": "^1.5.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "framer-motion": "^11.3.30",
@@ -3723,6 +3724,44 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
+      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vercel/edge": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@supabase/supabase-js": "^2.50.0",
+    "@vercel/analytics": "^1.5.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "framer-motion": "^11.3.30",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { clsx } from "clsx";
 import { Roboto } from "next/font/google";
 import { AuthProvider } from '@/components/auth-provider'; // Added import
+import { Analytics } from "@vercel/analytics/react"
 
 const inter = Inter({ subsets: ["latin"] });
 const roboto = Roboto({ subsets: ["latin"], weight: ["400", "700"] });
@@ -42,6 +43,7 @@ export default function RootLayout({
       <body className={clsx(inter.className, roboto.className, "antialiased")}>
         <AuthProvider> {/* Added AuthProvider wrapper */}
           {children}
+          <Analytics />
         </AuthProvider>
       </body>
     </html>


### PR DESCRIPTION
This commit integrates Vercel Analytics into the application.

- Installs the `@vercel/analytics` package.
- Imports the `Analytics` component into the root layout (`src/app/layout.tsx`).
- Adds the `<Analytics />` component to the `body` of the application to enable tracking.

Note: The component is imported from `@vercel/analytics/react`, which is the recommended path for Next.js applications using the App Router, rather than the older `@vercel/analytics/next` path.